### PR TITLE
Implement Ruff code formatting checker

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,24 @@
+name: Ruff
+on: 
+    push:
+        branches:
+            - main
+        paths:
+          - '.github/workflows/ruff.yml'
+          - 'ruff.toml'
+          - '**.py'
+    pull_request:
+        branches:
+            - main
+        paths:
+            - '.github/workflows/ruff.yml'
+            - 'ruff.toml'
+            - '**.py'
+    workflow_dispatch:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ This repository contains the code that is run on the Judge Queuer, which is resp
 This is a Python repository, with the main entrypoint file being `judgequeuer.py`.
 
 For development, a virtual environment is recommended. You can install dependencies with `pip install -r requirements.txt`.
+
+## Ruff
+For proper code formatting, we use Ruff. When you create a pull request, Ruff automatically checks the code and tells you about any possible formatting errors.
+
+If you want to use Ruff locally, install it with `pip install ruff`, then use `ruff check` to check for errors.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,33 @@
+preview = true
+
+extend-exclude = [".github"]
+
+line-length = 100
+indent-width = 4
+
+# Assume Python 3.12
+target-version = "py312"
+
+[lint]
+# Here we set the rules we want to use.
+# E1 - spacing/indentation (https://docs.astral.sh/ruff/rules/#pycodestyle-e-w)
+# E22 - whitespace (https://docs.astral.sh/ruff/rules/#pycodestyle-e-w) [preview]
+# E252 - whitespace (https://docs.astral.sh/ruff/rules/#pycodestyle-e-w) [preview]
+# E4 - imports (https://docs.astral.sh/ruff/rules/#pycodestyle-e-w)
+# E7 - statement (https://docs.astral.sh/ruff/rules/#pycodestyle-e-w)
+# F - (https://docs.astral.sh/ruff/rules/#pyflakes-f) [preview]
+# C901 - complex-structure (https://docs.astral.sh/ruff/rules/#pycodestyle-e-w)
+# N - naming convention (https://docs.astral.sh/ruff/rules/#pep8-naming-n)
+# COM - commas (https://docs.astral.sh/ruff/rules/#flake8-commas-com)
+# I - isort (https://docs.astral.sh/ruff/rules/#isort-i)
+# We could also add the following rules:
+# "ANN0" - missing-type-function-argument (https://docs.astral.sh/ruff/rules/#flake8-annotations-ann)
+# "ANN201" - missing-return-type-undocumented-public-function (https://docs.astral.sh/ruff/rules/#flake8-annotations-ann)
+# Sometimes useful:
+# ERA - commented-out-code (https://docs.astral.sh/ruff/rules/#eradicate-era)
+# E5 - line length (https://docs.astral.sh/ruff/rules/#pycodestyle-e-w)
+select = ["E1", "E22", "E252", "E4", "E7", "E9", "F", "W291", "C901", "N", "COM818", "COM819", "I"]
+
+# Here we set the rules we want to ignore.
+# N804 - invalid-first-argument-name-for-class-method (https://docs.astral.sh/ruff/rules/#pep8-naming-n)
+ignore = ["N804", "C901"]


### PR DESCRIPTION
Mostly same as the 'website' repository. Contains instructions in README on how to use, GitHub Actions CI, and a configuration for Ruff itself.