### PR TITLE
Update arg format of start command

### DIFF
--- a/azureevaluator.py
+++ b/azureevaluator.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 
 from azure.mgmt.compute.models import (
-    VirtualMachine,
     VirtualMachineScaleSet,
     VirtualMachineScaleSetVM,
 )
@@ -229,8 +228,10 @@ class JudgeVMSS:
                         await asyncio.sleep(1)
                         # TODO: implement timeout
 
+                cpus, memory = await self.azure.get_vm_size(vm.name)
+                
                 # Create and safe vm class
-                judgevm = JudgeVM(vm, avm, machine_name, self.azure)
+                judgevm = JudgeVM(vm, machine_name, self.azure, cpus, memory)
                 self.judgevm_dict[vm.name] = judgevm
 
         for key in list(self.judgevm_dict):
@@ -264,23 +265,18 @@ class JudgeVM:
     An Azure Virtual Machine.
     """
     vm: VirtualMachineScaleSetVM
-    avm: VirtualMachine
     machine_name: str
     azure: Azure
     free_cpu: int
-    free_gpu: int
     free_memory: int
     tasks = []
 
-    def __init__(self, vm: VirtualMachineScaleSetVM, avm: VirtualMachine, machine_name: str, azure: Azure):
+    def __init__(self, vm: VirtualMachineScaleSetVM, machine_name: str, azure: Azure, cpus: int, memory: int):
         self.vm = vm
-        self.avm = avm
         self.machine_name = machine_name
         self.azure = azure
-        # TODO replace hardcoded values (if possible, get from `vm`)
-        self.free_cpu = 10
-        self.free_gpu = 2
-        self.free_memory = 50
+        self.free_cpu = cpus
+        self.free_memory = memory
     
     async def check_capacity(self, cpus: int, memory: int) -> bool:
         """

--- a/azurewrap/asyncwrap.py
+++ b/azurewrap/asyncwrap.py
@@ -65,6 +65,9 @@ class AsyncAzure(Azure):
     
     def get_vm(self, *args, **kwargs):
         return self.__run(super().get_vm(*args, **kwargs))
+    
+    def get_vm_size(self, *args, **kwargs):
+        return self.__run(super().get_vm_size(*args, **kwargs))
 
     def create_vmss(self, *args, **kwargs):
         return self.__run(super().create_vmss(*args, **kwargs))

--- a/azurewrap/base.py
+++ b/azurewrap/base.py
@@ -118,6 +118,23 @@ class Azure:
         """
         return await self.compute_client.virtual_machines.get(self.resource_group_name, name)
 
+    async def get_vm_size(self, vm_name: str):
+        # Get the VM details
+        vm = await self.compute_client.virtual_machines.get(self.resource_group_name, vm_name)
+
+        # Get the VM size (hardware profile)
+        vm_size = vm.hardware_profile.vm_size
+
+        # Use the vm_size to get the VM size details
+        vm_sizes = self.compute_client.virtual_machine_sizes.list(location=vm.location)
+        async for size in vm_sizes:
+            if size.name == vm_size:
+                cpu_cores = size.number_of_cores
+                memory_in_mb = size.memory_in_mb
+                return cpu_cores, memory_in_mb
+        
+        raise ValueError("VM Size not found")
+
     #
     # Modification functions
     #

--- a/judgequeuer.py
+++ b/judgequeuer.py
@@ -11,7 +11,7 @@ import os
 from azureevaluator import AzureEvaluator
 from azurewrap import Azure
 from custom_logger import main_logger
-from models import JudgeRequest, MachineType, ResourceSpecification, Submission
+from models import JudgeRequest, MachineType, Submission
 from protocol import judge_protocol_handler, website_protocol_handler
 
 # Initialize the logger
@@ -51,8 +51,8 @@ async def main():
 async def send_test_submission():
     submission = Submission(1, "https://storagebenchlab.blob.core.windows.net/submissions/submission.zip", "https://storagebenchlab.blob.core.windows.net/validators/validator.zip")
     machine_type = MachineType("Standard_B1s", "Standard")
-    resource_allocation = ResourceSpecification(num_cpu=1, num_memory=10, num_gpu=0, machine_type=machine_type, time_limit=30)
-    judge_request = JudgeRequest(submission, resource_allocation)
+    # TODO sample data from website
+    judge_request = JudgeRequest(submission, machine_type, cpus=1, memory=10, evaluation_settings={}, benchmark_instances={})
 
     # Test out submitting judge request
     logger.info("Submitting judge request...")

--- a/judgequeuer.py
+++ b/judgequeuer.py
@@ -58,11 +58,9 @@ async def send_test_submission():
 		"machine_type":"Standard_B1s"
 	}
     benchmark_instancs = {
-		"706e2604-224a-4c3e-8b1c-f9418200c232":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw",
-		"7e36136f-2462-4273-85ee-2e6a641b4198":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw",
-		"8bb927b2-8904-45db-bc1d-2ac2daf61d10":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw",
-		"bf8756f8-95a9-4d24-a0d4-e74bf49cecbb":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw"
-	}
+        '0a800b64-0cce-4cb2-95ab-39a5064ece4e': 'https://storagebenchlab.blob.core.windows.net/benchmark-instances-test-validator/instance2.txt',
+        '83a8977e-760a-4d44-9a67-e07ca4d4c155': 'https://storagebenchlab.blob.core.windows.net/benchmark-instances-test-validator/instance1.txt'
+    }
     judge_request = JudgeRequest(submission, machine_type, cpus=1, memory=256, evaluation_settings=evaluation_settings, benchmark_instances=benchmark_instancs)
 
     # Test out submitting judge request

--- a/judgequeuer.py
+++ b/judgequeuer.py
@@ -51,8 +51,19 @@ async def main():
 async def send_test_submission():
     submission = Submission(1, "https://storagebenchlab.blob.core.windows.net/submissions/submission.zip", "https://storagebenchlab.blob.core.windows.net/validators/validator.zip")
     machine_type = MachineType("Standard_B1s", "Standard")
-    # TODO sample data from website
-    judge_request = JudgeRequest(submission, machine_type, cpus=1, memory=10, evaluation_settings={}, benchmark_instances={})
+    evaluation_settings = {
+        "cpu":1,
+		"time_limit":60.0,
+		"memory":256,
+		"machine_type":"Standard_B1s"
+	}
+    benchmark_instancs = {
+		"706e2604-224a-4c3e-8b1c-f9418200c232":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw",
+		"7e36136f-2462-4273-85ee-2e6a641b4198":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw",
+		"8bb927b2-8904-45db-bc1d-2ac2daf61d10":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw",
+		"bf8756f8-95a9-4d24-a0d4-e74bf49cecbb":"https://storagebenchlab.blob.core.windows.net/benchmark-instances-vrptw-homberger-200/C1_2_1.200.20.vrptw"
+	}
+    judge_request = JudgeRequest(submission, machine_type, cpus=1, memory=256, evaluation_settings=evaluation_settings, benchmark_instances=benchmark_instancs)
 
     # Test out submitting judge request
     logger.info("Submitting judge request...")

--- a/models.py
+++ b/models.py
@@ -29,23 +29,6 @@ class MachineType:
 
         return MachineType(name=name, tier=parts[0])
 
-class ResourceSpecification:
-    """
-    The specification of allocated resources to evaluate a submission.
-    """
-    num_cpu: int
-    num_memory: int
-    num_gpu: int
-    machine_type: 'MachineType'
-    time_limit: int # in seconds
-
-    def __init__(self, num_cpu: int, num_memory: int, num_gpu: int, machine_type: 'MachineType', time_limit: int):
-        self.num_cpu = num_cpu
-        self.num_memory = num_memory # in MB
-        self.num_gpu = num_gpu
-        self.machine_type = machine_type
-        self.time_limit = time_limit
-
 class SubmissionType(Enum):
     """
     The type of a submission: either code, or solution.
@@ -72,11 +55,19 @@ class JudgeRequest:
     A request for a submission to be evaluated according to some resource specification.
     """
     submission: 'Submission'
-    resource_specification: 'ResourceSpecification'
+    machine_type: MachineType
+    cpus: int
+    memory: int # MB
+    evaluation_settings: dict
+    benchmark_instances: dict[str, str]
 
-    def __init__(self, submission: 'Submission', resource_specification: 'ResourceSpecification'):
+    def __init__(self, submission: 'Submission', machine_type: MachineType, cpus: int, memory: int, evaluation_settings: dict, benchmark_instances: dict[str, str]):
         self.submission = submission
-        self.resource_specification = resource_specification
+        self.machine_type = machine_type
+        self.cpus = cpus
+        self.memory = memory
+        self.evalution_settings = evaluation_settings
+        self.benchmark_instances = benchmark_instances
 
 class JudgeResult:
     """

--- a/models.py
+++ b/models.py
@@ -66,7 +66,7 @@ class JudgeRequest:
         self.machine_type = machine_type
         self.cpus = cpus
         self.memory = memory
-        self.evalution_settings = evaluation_settings
+        self.evaluation_settings = evaluation_settings
         self.benchmark_instances = benchmark_instances
 
 class JudgeResult:

--- a/protocol/website/commands/start_command.py
+++ b/protocol/website/commands/start_command.py
@@ -3,7 +3,6 @@ from custom_logger import main_logger
 from models import (
     JudgeRequest,
     MachineType,
-    ResourceSpecification,
     Submission,
     SubmissionType,
 )
@@ -22,15 +21,20 @@ class StartCommand(Command):
     @staticmethod
     async def execute(args: dict):
         # Deserialization of the arguments
-        machine_type = MachineType.from_name(args["machine_type"])
-        submission_type = {"code": SubmissionType.CODE, "solution": SubmissionType.SOLUTION}[args["submission_type"]]
-        resource_specification = ResourceSpecification(num_cpu=args["cpus"],
-                                                       num_memory=args["memory"],
-                                                       num_gpu=args["gpus"],
-                                                       machine_type=machine_type,
-                                                       time_limit=args["time_limit"])
-        submission = Submission(submission_type, args["source_url"], args["validator_url"])
-        judge_request = JudgeRequest(submission, resource_specification)
+        evaluation_settings: dict = args["evaluation_settings"]
+        benchmark_instances: dict[str, str] = args["benchmark_instances"] # dict of ID to URL
+        submission_url: str = args["submission_url"]
+        validator_url: str = args["validator_url"]
+
+        # Extract relevant part of the evaluation settings
+        machine_type = MachineType.from_name(evaluation_settings["machine_type"])
+        cpus = evaluation_settings["cpus"]
+        memory = evaluation_settings["memory"]
+
+        # Form models for the judge request
+        submission_type = SubmissionType.CODE
+        submission = Submission(submission_type, submission_url, validator_url)
+        judge_request = JudgeRequest(submission, machine_type, cpus, memory, evaluation_settings, benchmark_instances)
 
         # Submit the request to the evaluator
         try:

--- a/protocol/website/commands/start_command.py
+++ b/protocol/website/commands/start_command.py
@@ -28,7 +28,7 @@ class StartCommand(Command):
 
         # Extract relevant part of the evaluation settings
         machine_type = MachineType.from_name(evaluation_settings["machine_type"])
-        cpus = evaluation_settings["cpus"]
+        cpus = evaluation_settings["cpu"]
         memory = evaluation_settings["memory"]
 
         # Form models for the judge request


### PR DESCRIPTION
Can't test rn, needs to wait for the container side and the website side as well

Converts the start command to the following format:
```
evaluation settings (dict that requires 'cpu', 'memory' and 'machine_type')
benchmark instances: dict from ID to URL
submission URL: str
validator URL: str
```

- Changed start command arg format (see above), now evaluation settings part is more dynamic
- Eliminate VM if unused after end of submission
- Load VM with proper CPU & memory values