### PR TITLE
Fix production deployment Azure credentials issue

### DIFF
--- a/azurewrap/base.py
+++ b/azurewrap/base.py
@@ -30,7 +30,9 @@ class Azure:
     subscription_id: str
 
     def __init__(self, subscription_id: str, resource_group_name: str):
-        self.credentials = DefaultAzureCredential()
+        # Exclude managed identity credential, as it was giving Azure deployment SSH
+        # (when using portal-based SSH connection, Azure added Managed Identity Credentials to the VM, which took priority over the Azure CLI credentials)
+        self.credentials = DefaultAzureCredential(exclude_managed_identity_credential=True)
 
         self.compute_client = ComputeManagementClient(self.credentials, subscription_id)
         self.network_client = NetworkManagementClient(self.credentials, subscription_id)

--- a/azurewrap/base.py
+++ b/azurewrap/base.py
@@ -30,7 +30,7 @@ class Azure:
     subscription_id: str
 
     def __init__(self, subscription_id: str, resource_group_name: str):
-        # Exclude managed identity credential, as it was giving Azure deployment SSH
+        # Exclude managed identity credential, as it was giving Azure deployment issues
         # (when using portal-based SSH connection, Azure added Managed Identity Credentials to the VM, which took priority over the Azure CLI credentials)
         self.credentials = DefaultAzureCredential(exclude_managed_identity_credential=True)
 


### PR DESCRIPTION
When logging in with SSH to the VM via the Azure Portal, Azure added a Managed Identity to the machine:
![image](https://github.com/SEP-TU-e-2024/JudgeQueuer/assets/29547183/46811451-0f2f-4224-8497-6cab7b594c64)

The Judge needs Azure credentials on the machine to interact with the environment, for which there are many credentials providing options:
![image](https://github.com/SEP-TU-e-2024/JudgeQueuer/assets/29547183/a298aa4c-c01b-4620-bc2b-6f39dd03bd11)

Since the Managed Identity Credentials have a higher priority than the Azure CLI credentials (which we use for deployment), these credentials were taken for use with the program instead of the Azure CLI credentials. However, these credentials were only made for SSH connections, and therefore are unauthorized to interact with VMs, VMSS's and other Azure resources the Judge needs access to. Therefore, the program failed during the first acceptance test.